### PR TITLE
Add delete file api

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -21,7 +21,10 @@ from api.settings import (
     UPLOADED_FILE_PATH_PREFIX,
     METASTORE_DEV_SERVICE,
 )
-from api.utils import get_valid_filename
+from api.utils import (
+    get_valid_filename,
+    is_file_in_directory,
+)
 
 # Metadata
 description = "An API for downloading files."
@@ -251,6 +254,14 @@ class DeleteFile:
 
         """
         file_path = req.params.get('path', '')
+
+        # Check if path is in the UPLOADED_FILE_PATH_PREFIX directory
+        if not is_file_in_directory(file_path, UPLOADED_FILE_PATH_PREFIX):
+            resp.status_code = 403
+            resp.media = {
+                'reason': f'Deleting ({file_path}) is forbbiden.',
+            }
+            return
 
         # Detele file
         try:

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,3 +1,4 @@
+import os.path
 import re
 
 
@@ -15,3 +16,24 @@ def get_valid_filename(name):
     s = str(name).strip().replace(' ', '_')
     s = re.sub(r'(?u)[^-\w.]', '', s)
     return s
+
+
+def is_file_in_directory(file: str, directory: str) -> bool:
+    """Return if the file is in the directory.
+    Taken from https://stackoverflow.com/q/3812849.
+
+    Args:
+        file (str): Path to file to check.
+        directory (str): path to directory to check.
+
+    Returns:
+        (bool): Whether the file is in the specified directory.
+
+    """
+    # make both absolute
+    directory = os.path.join(os.path.realpath(directory), '')
+    file = os.path.realpath(file)
+
+    # return true, if the common prefix of both is equal to directory
+    # e.g. /a/b/c/d.rst and directory is /a/b, the common prefix is /a/b
+    return os.path.commonprefix([file, directory]) == directory

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -252,6 +252,8 @@ def test_delete_file_200(api):
     assert 'save_file_path' in data.keys()
     save_file_path = data['save_file_path']
 
+    time.sleep(0.5)
+
     # Delete file
     params = {
         'path': save_file_path,
@@ -270,20 +272,43 @@ def test_delete_file_200(api):
 
 def test_delete_file_404(api):
     params = {
-        'path': '/file_path_that_does_not_exist',
+        'path': os.path.join(
+            UPLOADED_FILE_PATH_PREFIX,
+            'file_path_that_does_not_exist',
+        ),
     }
     r = api.requests.delete(url=api.url_for(server.DeleteFile), params=params)
     assert r.status_code == 404
 
 
 def test_delete_file_delete_directory_get_403(api):
-    os.mkdir('/tmp/dir_to_delete_test')
+    path_to_directory = os.path.join(
+        UPLOADED_FILE_PATH_PREFIX,
+        'dir_to_delete_test',
+    )
+    os.mkdir(path_to_directory)
     params = {
-        'path': '/tmp/dir_to_delete_test',
+        'path': path_to_directory,
     }
     r = api.requests.delete(url=api.url_for(server.DeleteFile), params=params)
-    os.rmdir('/tmp/dir_to_delete_test')
+    os.rmdir(path_to_directory)
     assert r.status_code == 403
+
+
+def test_delete_file_outside_upload_directory_403(api):
+    # Touch file
+    path_to_file = '/tmp/file_to_delete'
+    with open(path_to_file, 'w') as _:
+        pass
+
+    params = {
+        'path': path_to_file,
+    }
+    r = api.requests.delete(url=api.url_for(server.DeleteFile), params=params)
+    assert r.status_code == 403
+
+    # Delete file
+    os.remove(path_to_file)
 
 
 @pytest.mark.parametrize("file_path, content_type", file_pathes)


### PR DESCRIPTION
## What?

ファイルの実体を削除するAPI追加

## Why?

ファイル実体の削除も api-file-provider で行いたい

## See also [Optional]

- Issue #8 

## Screenshot or video [Optional]

## TODOs

- [x] 削除機能追加
- [x] ファイルが無ければ404
- [x] 権限がなければ403
- [x] 削除できるファイルを制限（UPLOADED_FILE_PATH_PREFIX 以下に限定）