### PR TITLE
Add env vars to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,7 @@ $ docker-compose up
 ## Environment variables
 
 - `META_STORE_SERVICE`: URL of `api-meta-store`
-- `UPLOADED_FILE_PATH_PREFIX`: Path to the directory to save uploaded files in.
+- `UPLOADED_FILE_PATH_PREFIX`: Path to the directory to save uploaded files in. If not set, `/opt/uploaded_data` will be used.
 - `PORT`: Port to run server on.
 - `API_DEBUG`: Enable debug mode if true.
 - `API_TOKEN`: Token as a string used for accessing external API while running tests. If not set, tests that use external API will be skipped.
-
-
-## Tips
-
-### How to set directory to store uploaded files
-
-Set UPLOADED_FILE_PATH_PREFIX environmental variable. If not set, `/opt/uploaded_data` will be used.
-
-### How to test with meta-store service
-
-Set API_TOKEN environmental variable on running tests. The test will be skipped otherwise.


### PR DESCRIPTION
## What?

READMEのTipsの内容を環境変数リストに移動

## Why?

環境変数は全部まとまっていたほうがわかりやすいため
