### PR TITLE
Fix vulnerability on downloading and deleting file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,7 @@ passenv =
     API_CATALOG
     API_TOKEN
     API_DEBUG
-setenv = 
-    UPLOADED_FILE_PATH_PREFIX = /opt/test_uploaded_files_directory
+    UPLOADED_FILE_PATH_PREFIX
 commands =
     pytest test/
 


### PR DESCRIPTION
## What?

ファイルのパスではなくUUIDを受け取り、meta-store からパスを取得するようにした

## Why?

ファイルのダウンロード・削除時の権限チェック回避バグを修正するため

## See also [Optional]

https://github.com/dataware-tools/dataware-tools/issues/72

## Screenshot or video [Optional]
