### PR TITLE
Avoid adding new column `database-id`

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -515,7 +515,6 @@ def _update_metastore(
         return (False, None)
     request_data = {
         'record_id': record_id,
-        'database_id': database_id,
         'path': save_file_path,
         **file_metadata
     }


### PR DESCRIPTION
## What?
Remove `database_id` from the metadata to update when a file is uploaded

## Why?
To avoid adding column `database-id` unexpectedly
