### PR TITLE
Support Jest 28

### DIFF
--- a/build_client/typescript/package.json
+++ b/build_client/typescript/package.json
@@ -13,6 +13,10 @@
       "import": "./dist/node/index.mjs",
       "require": "./dist/node/index.cjs"
     },
+    "browser": {
+      "import": "./dist/browser/index.mjs",
+      "require": "./dist/browser/index.cjs"
+    },
     "default": [
       "./dist/browser/index.mjs"
     ]


### PR DESCRIPTION
## What?
Support Jset v28

## Why?
Jest v28 で testEnvironment = jsdom にすると、モジュール解決できずにエラーが出たから

## See also
https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149